### PR TITLE
Fix instrument return

### DIFF
--- a/lib/instrument.js
+++ b/lib/instrument.js
@@ -62,6 +62,8 @@ function instrument(code) {
   var pos = 0;
   var i = 0;
   var args = '';
+  var rng = [];
+  var endPos = 0;
 
   var tree = esprima.parse(code, { comment: true, loc: true, range: true });
 
@@ -94,7 +96,8 @@ function instrument(code) {
       functionList.push({
         name: 'return',
         fn: obj && obj.name,
-        range: node.range
+        range: node.range,
+        argument: node.argument == null ? null : node.argument.range
       });
     } else if (node.type === 'FunctionExpression') {
       parent = path[0];
@@ -151,11 +154,19 @@ function instrument(code) {
     if (functionList[i].name === 'return') {
       signature = ' _$TypedJS.ret(';
       pos = functionList[i].range[0] + 6;
-      args = code.slice(pos, functionList[i].range[1]);
-      args = (!!args) ? args : 'undefined';
+
+      if (functionList[i].argument == null) {
+        args = 'undefined';
+        endPos = functionList[i].range[1];
+      } else {
+        rng = functionList[i].argument;
+        args = code.slice(rng[0], rng[1] + 1);
+        endPos = rng[1] + 1;
+      }
+
       code = code.slice(0, pos) + signature +
         '\'' + functionList[i].fn + '\', ' + args + ')' +
-        code.slice(functionList[i].range[1], code.length);
+        code.slice(endPos, code.length);
     } else {
       signature = '_$TypedJS.args(\'' + functionList[i].name + '\', arguments);';
       pos = functionList[i].blockStart + 1;


### PR DESCRIPTION
I know it's a bit too late, but maybe you can use it though

It fails on return statements like

``` javascript
function a() {return 2} // don't know what happened there. "2" was outside _$TypedJS.ret()

function b() {return   } // not recognized as "return" without argument

function b() {
    { return 2} // same here, "2" outside _$TypedJS.ret()
}
```
