### PR TITLE
fix for issue #4

### DIFF
--- a/src/automated/run_tests.coffee
+++ b/src/automated/run_tests.coffee
@@ -3,7 +3,7 @@ Tests = require './tests'
 class RunTests extends Tests
 
   run: ->
-    super @typedjs.run_tests_on_string @code
+    super ((@typedjs.run_tests_on_string @code) || [[],[]])
 
 
 module.exports = RunTests


### PR DESCRIPTION
trivial fix to return defined but empty results for `run_tests_on_string` code without any type annotations.
